### PR TITLE
Fix Waterlog Removal When Y < 0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>pro.dracarys</groupId>
     <artifactId>waterlogfix</artifactId>
     <name>WaterlogFix</name>
-    <version>1.5</version>
+    <version>1.6</version>
     <packaging>jar</packaging>
     <url>https://dracarys.pro</url>
 

--- a/src/main/java/pro/dracarys/WaterlogFix/listeners/ExplosionListener.java
+++ b/src/main/java/pro/dracarys/WaterlogFix/listeners/ExplosionListener.java
@@ -43,7 +43,7 @@ public class ExplosionListener implements Listener {
             for (int y = -radius; y <= radius; y++) {
                 for (int z = -radius; z <= radius; z++) {
                     Location loc = new Location(source.getWorld(), x + source.getX(), y + source.getY(), z + source.getZ());
-                    if (source.distance(loc) <= dmgRadius && loc.getY() > 0 && (chance == 1 || Math.random() <= chance)) {
+                    if (source.distance(loc) <= dmgRadius && (chance == 1 || Math.random() <= chance)) {
                         setWaterlogged(loc.getBlock(), false);
                     }
                 }


### PR DESCRIPTION
A bounds check is not needed here. `Location#getBlock()` is annotated as `@NotNull` and does not throw any exceptions. Tested on `git-Paper-349 (MC: 1.20.4)`. 

Closes #2.